### PR TITLE
[Feat] Websocket 실시간 메시징 구현

### DIFF
--- a/module-application/build.gradle
+++ b/module-application/build.gradle
@@ -9,6 +9,7 @@ project(':module-application') {
         implementation project(':module-infra:persistence-database')
         implementation project(':module-infra:persistence-redis')
         implementation project(':module-infra:security')
+        implementation project(':module-messaging')
 
         implementation 'org.springframework.boot:spring-boot-starter-web'
 

--- a/module-messaging/build.gradle
+++ b/module-messaging/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+}
+
+group = 'org.opensource'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/module-messaging/build.gradle
+++ b/module-messaging/build.gradle
@@ -1,19 +1,10 @@
-plugins {
-    id 'java'
-}
+bootJar { enabled = false }
+jar { enabled = true }
 
-group = 'org.opensource'
-version = '0.0.1-SNAPSHOT'
+project(":module-messaging") {
+    dependencies {
+        implementation project(':module-common')
 
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-}
-
-test {
-    useJUnitPlatform()
+        implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    }
 }

--- a/module-messaging/src/main/java/org/opensource/message/UserInfo.java
+++ b/module-messaging/src/main/java/org/opensource/message/UserInfo.java
@@ -1,0 +1,14 @@
+package org.opensource.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.socket.WebSocketSession;
+
+@Getter
+@AllArgsConstructor
+public class UserInfo {
+    private String name;
+    private Long userId;
+    private String chatRoomId;
+    private WebSocketSession session;
+}

--- a/module-messaging/src/main/java/org/opensource/message/UserInfo.java
+++ b/module-messaging/src/main/java/org/opensource/message/UserInfo.java
@@ -9,6 +9,6 @@ import org.springframework.web.socket.WebSocketSession;
 public class UserInfo {
     private String name;
     private Long userId;
-    private String chatRoomId;
+    private Long chatRoomId;
     private WebSocketSession session;
 }

--- a/module-messaging/src/main/java/org/opensource/message/WebSocketConfig.java
+++ b/module-messaging/src/main/java/org/opensource/message/WebSocketConfig.java
@@ -13,7 +13,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry
-                .addHandler(signalingSocketHandler(), "/ws-real-chat")
+                .addHandler(signalingSocketHandler(), "/ws-booking-messaging")
                 .setAllowedOrigins("*");
     }
 

--- a/module-messaging/src/main/java/org/opensource/message/WebSocketConfig.java
+++ b/module-messaging/src/main/java/org/opensource/message/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package org.opensource.message;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry
+                .addHandler(signalingSocketHandler(), "/ws-real-chat")
+                .setAllowedOrigins("*");
+    }
+
+    @Bean
+    public WebSocketHandler signalingSocketHandler() {
+        return new WebSocketHandler();
+    }
+}

--- a/module-messaging/src/main/java/org/opensource/message/WebSocketHandler.java
+++ b/module-messaging/src/main/java/org/opensource/message/WebSocketHandler.java
@@ -1,5 +1,7 @@
 package org.opensource.message;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -13,6 +15,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class WebSocketHandler extends TextWebSocketHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketHandler.class);
 
     // sessionMap Key - UserInfo chatRoomId
     private final Map<String, Set<UserInfo>> sessionMap = new ConcurrentHashMap<>();
@@ -95,6 +99,8 @@ public class WebSocketHandler extends TextWebSocketHandler {
             String name = session.getHandshakeHeaders().getFirst("name");
             String clientIdInString = session.getHandshakeHeaders().getFirst("userId");
             String chatRoomId = session.getHandshakeHeaders().getFirst("chatRoomId");
+
+            logger.info("웹소켓 연결 성공: userId={}, name={}, chatRoomId={}", clientIdInString, name, chatRoomId);
 
             // 필수 헤더 값이 누락된 경우 예외 처리
             if (name == null || clientIdInString == null || chatRoomId == null) {

--- a/module-messaging/src/main/java/org/opensource/message/WebSocketHandler.java
+++ b/module-messaging/src/main/java/org/opensource/message/WebSocketHandler.java
@@ -54,9 +54,9 @@ public class WebSocketHandler extends TextWebSocketHandler {
             usersInChatRoom.removeIf(user -> user.getUserId().equals(userInfo.getUserId()));
 
             // 만약 해당 채팅방에 남아있는 유저가 없다면 채팅방 삭제
-            if (usersInChatRoom.isEmpty()) {
-                sessionMap.remove(userInfo.getChatRoomId());
-            }
+//            if (usersInChatRoom.isEmpty()) {
+//                sessionMap.remove(userInfo.getChatRoomId());
+//            }
         }
 
         sendMessageToChatRoom(userInfo.getChatRoomId(), userInfo.getName() + "님이 대화방을 나가셨습니다.");

--- a/module-messaging/src/main/java/org/opensource/message/WebSocketHandler.java
+++ b/module-messaging/src/main/java/org/opensource/message/WebSocketHandler.java
@@ -1,0 +1,123 @@
+package org.opensource.message;
+
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class WebSocketHandler extends TextWebSocketHandler {
+
+    // sessionMap Key - UserInfo chatRoomId
+    private final Map<String, Set<UserInfo>> sessionMap = new ConcurrentHashMap<>();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        super.afterConnectionEstablished(session);
+        UserInfo userInfo = extractUserInfo(session);
+
+        sessionMap.computeIfAbsent(userInfo.getChatRoomId(), k -> new HashSet<>()).add(userInfo);
+        sendMessageToChatRoom(userInfo.getChatRoomId(), userInfo.getName() + "님이 대화방에 들어오셨습니다.");
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage textMessage) throws Exception {
+        super.handleTextMessage(session, textMessage);
+        UserInfo userInfo = extractUserInfo(session);
+
+        String textMessagePayload = textMessage.getPayload();
+        String message = userInfo.getName() + " : " + textMessagePayload;
+        sendMessageToChatRoomExceptSelf(userInfo.getChatRoomId(), message, userInfo);
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+        super.handleTransportError(session, exception);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        UserInfo userInfo = extractUserInfo(session);
+
+        Set<UserInfo> usersInChatRoom = sessionMap.get(userInfo.getChatRoomId());
+        if (usersInChatRoom != null) {
+            usersInChatRoom.removeIf(user -> user.getUserId().equals(userInfo.getUserId()));
+
+            // 만약 해당 채팅방에 남아있는 유저가 없다면 채팅방 삭제
+            if (usersInChatRoom.isEmpty()) {
+                sessionMap.remove(userInfo.getChatRoomId());
+            }
+        }
+
+        sendMessageToChatRoom(userInfo.getChatRoomId(), userInfo.getName() + "님이 대화방을 나가셨습니다.");
+    }
+
+    private void sendMessageToChatRoom(String chatRoomId, String message) throws IOException {
+        Set<UserInfo> users = sessionMap.get(chatRoomId);
+
+        if (users != null) {
+            for (UserInfo user : users) {
+                try {
+                    user.getSession().sendMessage(new TextMessage(message));
+                } catch (IOException e) {
+                    // 오류 처리
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    private void sendMessageToChatRoomExceptSelf(String chatRoomId, String message, UserInfo userInfo) throws IOException {
+        Set<UserInfo> users = sessionMap.get(chatRoomId);
+        WebSocketSession session = userInfo.getSession();
+
+        if (users != null) {
+            for (UserInfo user : users) {
+                try {
+                    if(!session.getId().equals(user.getSession().getId())) {
+                        user.getSession().sendMessage(new TextMessage(message));
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    private UserInfo extractUserInfo(WebSocketSession session) throws IOException {
+        try {
+            String name = session.getHandshakeHeaders().getFirst("name");
+            String clientIdInString = session.getHandshakeHeaders().getFirst("userId");
+            String chatRoomId = session.getHandshakeHeaders().getFirst("chatRoomId");
+
+            // 필수 헤더 값이 누락된 경우 예외 처리
+            if (name == null || clientIdInString == null || chatRoomId == null) {
+                session.sendMessage(new TextMessage("Error: Missing required headers."));
+                session.close();
+                return null; // 조기 종료
+            }
+
+            long clientId;
+            try {
+                clientId = Long.parseLong(clientIdInString);
+            } catch (NumberFormatException e) {
+                session.sendMessage(new TextMessage("Error: Invalid userId format: " + clientIdInString));
+                session.close();
+                return null; // 조기 종료
+            }
+
+            return new UserInfo(name, clientId, chatRoomId, session);
+
+        } catch (Exception e) {
+            session.sendMessage(new TextMessage("Error: Unexpected server error."));
+            session.close();
+            throw new RuntimeException("WebSocket header processing failed", e);
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,5 @@ include 'module-external-api'
 include 'module-infra:persistence-database'
 include 'module-infra:persistence-redis'
 include 'module-infra:security'
+include 'module-messaging'
+


### PR DESCRIPTION
## #41  [Feat] Websocket 실시간 메시징 구현

### 구현상세
- module-messaging 생성하고 module-application에서 의존하도록 설정했습니다.
- 웹소켓을 연결하는 handshake 시점에서 헤더로 사용자 id, 참여하는 채팅방 id, 사용자 이름을 넣어 보냅니다.
- 사용자 그리고 채팅방의 존재 여부는 module-mesaging에서 처리하지 않고 모두 module-application에서 처리하도록 하려합니다.
- 현재는 WebSocketHandler의 sessionMap으로 채팅방별 사용자를 구분 관리하고 있지만, 이후 단일 서버를 다중화하는 방향으로 개발하며 메시지 브로커의 역할로 Redis를 사용할 예정입니다.

### 스크린샷
<img width="440" alt="스크린샷 2025-04-03 오후 5 50 00" src="https://github.com/user-attachments/assets/20c48f98-7a86-4497-aa27-c393b266e61a" />
<img width="535" alt="스크린샷 2025-04-03 오후 5 50 13" src="https://github.com/user-attachments/assets/c2adf65a-4dfd-4c1d-8e9a-c8a3180bd843" />
<img width="538" alt="스크린샷 2025-04-03 오후 5 50 52" src="https://github.com/user-attachments/assets/59873023-0a5d-4d17-9798-9f949e5f8134" />
<img width="544" alt="스크린샷 2025-04-03 오후 5 51 07" src="https://github.com/user-attachments/assets/abd44437-bf18-4ca2-9aba-d7cf35f66a34" />
