### PR TITLE
로그인 기능 구현

### DIFF
--- a/module-application/src/main/java/org/opensource/user/api/UserApi.java
+++ b/module-application/src/main/java/org/opensource/user/api/UserApi.java
@@ -2,7 +2,9 @@ package org.opensource.user.api;
 
 import dto.response.ApiResponse;
 import jakarta.validation.Valid;
+import org.opensource.user.dto.request.SignInRequestDto;
 import org.opensource.user.dto.request.SignUpRequestDto;
+import org.opensource.user.dto.response.SignInResponseDto;
 import org.opensource.user.dto.response.SignUpResponseDto;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -10,6 +12,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface UserApi {
     ApiResponse<SignUpResponseDto> signUp(
             @Valid @RequestBody SignUpRequestDto request
+    );
+
+    ApiResponse<SignInResponseDto> signIn(
+            @Valid @RequestBody SignInRequestDto request
     );
 
     ApiResponse emailExist(

--- a/module-application/src/main/java/org/opensource/user/api/UserController.java
+++ b/module-application/src/main/java/org/opensource/user/api/UserController.java
@@ -3,7 +3,9 @@ package org.opensource.user.api;
 import dto.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.opensource.user.dto.request.SignInRequestDto;
 import org.opensource.user.dto.request.SignUpRequestDto;
+import org.opensource.user.dto.response.SignInResponseDto;
 import org.opensource.user.dto.response.SignUpResponseDto;
 import org.opensource.user.facade.UserFacade;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,7 @@ import type.user.UserSuccessType;
 public class UserController implements UserApi {
     private final UserFacade userFacade;
 
+    @Override
     @PostMapping("/signup")
     public ApiResponse<SignUpResponseDto> signUp(
             @RequestBody @Valid final SignUpRequestDto request
@@ -22,6 +25,14 @@ public class UserController implements UserApi {
         return ApiResponse.success(UserSuccessType.SIGN_UP_SUCCESS, userFacade.signUp(request.getName(), request.getEmail(), request.getPassword()));
     }
 
+    @Override
+    @PostMapping("/signin")
+    public ApiResponse<SignInResponseDto> signIn(
+            @RequestBody @Valid SignInRequestDto request) {
+        return ApiResponse.success(UserSuccessType.SIGN_IN_SUCCESS, userFacade.signIn(request.getEmail(), request.getPassword()));
+    }
+
+    @Override
     @PostMapping("/email-exist")
     public ApiResponse emailExist(
             @RequestParam String email
@@ -29,6 +40,7 @@ public class UserController implements UserApi {
         userFacade.checkEmailExists(email);
         return ApiResponse.success(UserSuccessType.EMAIL_CAN_USE);
     }
+
 
     @PostMapping("/name-exist")
     public ApiResponse nameExist(

--- a/module-application/src/main/java/org/opensource/user/dto/request/SignInRequestDto.java
+++ b/module-application/src/main/java/org/opensource/user/dto/request/SignInRequestDto.java
@@ -1,0 +1,18 @@
+package org.opensource.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignInRequestDto {
+    @Email(message = "이메일 형식에 맞지 않습니다")
+    @NotBlank
+    private String email;
+
+    @NotNull
+    private String password;
+}

--- a/module-application/src/main/java/org/opensource/user/dto/request/SignUpRequestDto.java
+++ b/module-application/src/main/java/org/opensource/user/dto/request/SignUpRequestDto.java
@@ -1,13 +1,11 @@
 package org.opensource.user.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor

--- a/module-application/src/main/java/org/opensource/user/dto/response/SignInResponseDto.java
+++ b/module-application/src/main/java/org/opensource/user/dto/response/SignInResponseDto.java
@@ -1,0 +1,17 @@
+package org.opensource.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignInResponseDto {
+    private Long userId;
+    private String accessToken;
+
+    public static SignInResponseDto of(Long userId, String accessToken) {
+        return new SignInResponseDto(userId, accessToken);
+    }
+}

--- a/module-application/src/main/java/org/opensource/user/facade/UserFacade.java
+++ b/module-application/src/main/java/org/opensource/user/facade/UserFacade.java
@@ -2,10 +2,9 @@ package org.opensource.user.facade;
 
 import lombok.RequiredArgsConstructor;
 import org.opensource.user.domain.User;
-import org.opensource.user.domain.UserCredentials;
+import org.opensource.user.dto.response.SignInResponseDto;
 import org.opensource.user.dto.response.SignUpResponseDto;
 import org.opensource.user.mapper.UserMapper;
-import org.opensource.user.port.in.command.UserCreateCommand;
 import org.opensource.user.port.in.usecase.EmailAuthUseCase;
 import org.opensource.user.port.in.usecase.UserUseCase;
 import org.springframework.stereotype.Service;
@@ -38,6 +37,13 @@ public class UserFacade {
 
     public void checkNameExists(String name) {
         userUseCase.checkNameExists(name);
+    }
+
+    public SignInResponseDto signIn(String email, String password) {
+        String token = userUseCase.signIn(UserMapper.toUserSignInCommand(email, password));
+        Long userId = userUseCase.findUserByEmail(email).getId();
+
+        return SignInResponseDto.of(userId, token);
     }
 
     // 구현 필요

--- a/module-application/src/main/java/org/opensource/user/facade/UserFacade.java
+++ b/module-application/src/main/java/org/opensource/user/facade/UserFacade.java
@@ -48,6 +48,6 @@ public class UserFacade {
 
     // 구현 필요
     public User findUser(Long id) {
-        return User.builder().id(1L).build();
+        return userUseCase.findUserById(id);
     }
 }

--- a/module-application/src/main/java/org/opensource/user/mapper/UserMapper.java
+++ b/module-application/src/main/java/org/opensource/user/mapper/UserMapper.java
@@ -1,11 +1,18 @@
 package org.opensource.user.mapper;
 
 import org.opensource.user.port.in.command.UserCreateCommand;
+import org.opensource.user.port.in.command.UserSignInCommand;
 
 public class UserMapper {
     public static UserCreateCommand toUserCreateCommand(
             String name, String email, String password
     ) {
         return new UserCreateCommand(name, email, password);
+    }
+
+    public static UserSignInCommand toUserSignInCommand(
+            String email, String password
+    ) {
+        return new UserSignInCommand(email, password);
     }
 }

--- a/module-application/src/main/resources/yml/application-auth.yml
+++ b/module-application/src/main/resources/yml/application-auth.yml
@@ -10,3 +10,6 @@ spring:
           auth: true
           starttls:
             enable: true
+
+jwt:
+  secret: ${JWT_SECRET}

--- a/module-common/src/main/java/type/user/UserErrorType.java
+++ b/module-common/src/main/java/type/user/UserErrorType.java
@@ -8,7 +8,10 @@ public enum UserErrorType implements ErrorType {
     EMAIL_AUTH_TIMEOUT_ERROR(400, "인증 시간을 초과하였습니다. 다시 시도해주세요"),
     EMAIL_ALREADY_EXISTS(400, "이미 등록된 이메일입니다."),
     NAME_ALREADY_EXISTS(400, "이미 존재하는 이름입니다."),
-    SIGN_UP_ERROR(500, "회원가입에 실패하였습니다.")
+    SIGN_UP_ERROR(500, "회원가입에 실패하였습니다."),
+    EMAIL_NOT_EXIST(400, "등록된 이메일이 없습니다."),
+    TOKEN_TIME_EXPIRED_ERROR(401, "토큰 기간이 만료되었습니다."),
+    USER_PASSWORD_NOT_MATCH(401, "비밀번호를 잘못 입력하였습니다.")
     ;
 
     private final int code;

--- a/module-common/src/main/java/type/user/UserErrorType.java
+++ b/module-common/src/main/java/type/user/UserErrorType.java
@@ -11,7 +11,8 @@ public enum UserErrorType implements ErrorType {
     SIGN_UP_ERROR(500, "회원가입에 실패하였습니다."),
     EMAIL_NOT_EXIST(400, "등록된 이메일이 없습니다."),
     TOKEN_TIME_EXPIRED_ERROR(401, "토큰 기간이 만료되었습니다."),
-    USER_PASSWORD_NOT_MATCH(401, "비밀번호를 잘못 입력하였습니다.")
+    USER_PASSWORD_NOT_MATCH(401, "비밀번호를 잘못 입력하였습니다."),
+    USER_NOT_EXIST(400, "유저가 존재하지 않습니다.")
     ;
 
     private final int code;

--- a/module-common/src/main/java/type/user/UserSuccessType.java
+++ b/module-common/src/main/java/type/user/UserSuccessType.java
@@ -7,7 +7,8 @@ public enum UserSuccessType implements SuccessType {
     SEND_EMAIL_SUCCESS(200, "이메일을 성공적으로 전송하였습니다."),
     SIGN_UP_SUCCESS(200, "회원가입이 완료되었습니다."),
     EMAIL_CAN_USE(200, "사용 가능한 이메일입니다."),
-    NAME_CAN_USE(200, "사용 가능한 이름입니다.")
+    NAME_CAN_USE(200, "사용 가능한 이름입니다."),
+    SIGN_IN_SUCCESS(200, "로그인에 성공하였습니다.")
     ;
 
     private final int code;

--- a/module-domain/src/main/java/org/opensource/user/port/in/command/UserSignInCommand.java
+++ b/module-domain/src/main/java/org/opensource/user/port/in/command/UserSignInCommand.java
@@ -1,0 +1,4 @@
+package org.opensource.user.port.in.command;
+
+public record UserSignInCommand(String email, String password) {
+}

--- a/module-domain/src/main/java/org/opensource/user/port/in/usecase/UserUseCase.java
+++ b/module-domain/src/main/java/org/opensource/user/port/in/usecase/UserUseCase.java
@@ -14,4 +14,6 @@ public interface UserUseCase {
     void checkNameExists(String name);
 
     User findUserByEmail(String email);
+
+    User findUserById(Long id);
 }

--- a/module-domain/src/main/java/org/opensource/user/port/in/usecase/UserUseCase.java
+++ b/module-domain/src/main/java/org/opensource/user/port/in/usecase/UserUseCase.java
@@ -2,11 +2,16 @@ package org.opensource.user.port.in.usecase;
 
 import org.opensource.user.domain.User;
 import org.opensource.user.port.in.command.UserCreateCommand;
+import org.opensource.user.port.in.command.UserSignInCommand;
 
 public interface UserUseCase {
     User signUp(UserCreateCommand userCreateCommand);
 
+    String signIn(UserSignInCommand userSignInCommand);
+
     void checkEmailExists(String email);
 
     void checkNameExists(String name);
+
+    User findUserByEmail(String email);
 }

--- a/module-domain/src/main/java/org/opensource/user/port/out/PasswordEncoderPort.java
+++ b/module-domain/src/main/java/org/opensource/user/port/out/PasswordEncoderPort.java
@@ -2,4 +2,6 @@ package org.opensource.user.port.out;
 
 public interface PasswordEncoderPort {
     String encode(String password);
+
+    Boolean matches(String rawPassword, String encodedPassword);
 }

--- a/module-domain/src/main/java/org/opensource/user/port/out/SecurityPort.java
+++ b/module-domain/src/main/java/org/opensource/user/port/out/SecurityPort.java
@@ -1,0 +1,11 @@
+package org.opensource.user.port.out;
+
+import org.opensource.user.domain.UserCredentials;
+
+public interface SecurityPort {
+    String createToken(UserCredentials userCredentials);
+
+    Boolean verifyToken(String token);
+
+    String getJwtContents(String token);
+}

--- a/module-domain/src/main/java/org/opensource/user/port/out/persistence/UserCredentialsPersistencePort.java
+++ b/module-domain/src/main/java/org/opensource/user/port/out/persistence/UserCredentialsPersistencePort.java
@@ -2,6 +2,10 @@ package org.opensource.user.port.out.persistence;
 
 import org.opensource.user.domain.UserCredentials;
 
+import java.util.Optional;
+
 public interface UserCredentialsPersistencePort {
     void save(UserCredentials userCredentials);
+
+    Optional<UserCredentials> findByUserEmail(String email);
 }

--- a/module-domain/src/main/java/org/opensource/user/port/out/persistence/UserPersistencePort.java
+++ b/module-domain/src/main/java/org/opensource/user/port/out/persistence/UserPersistencePort.java
@@ -2,12 +2,16 @@ package org.opensource.user.port.out.persistence;
 
 import org.opensource.user.domain.User;
 
+import java.util.Optional;
+
 public interface UserPersistencePort {
-    User findByEmail(String email);
+    Optional<User> findByEmail(String email);
 
     Boolean existsByEmail(String email);
 
     Boolean existsByName(String name);
 
     void save(User user);
+
+    Optional<User> findById(Long id);
 }

--- a/module-domain/src/main/java/org/opensource/user/service/UserService.java
+++ b/module-domain/src/main/java/org/opensource/user/service/UserService.java
@@ -38,7 +38,8 @@ public class UserService implements UserUseCase {
 
             userPersistencePort.save(user);
 
-            User savedUser = userPersistencePort.findByEmail(userCreateCommand.email());
+            User savedUser = userPersistencePort.findByEmail(userCreateCommand.email())
+                    .orElseThrow(() -> new NotFoundException(UserErrorType.USER_NOT_EXIST));
 
             userCredentialsPersistencePort.save(UserCredentials.builder()
                     .user(savedUser)
@@ -84,7 +85,8 @@ public class UserService implements UserUseCase {
 
     @Override
     public User findUserByEmail(String email) {
-        return userPersistencePort.findByEmail(email);
+        return userPersistencePort.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException(UserErrorType.EMAIL_NOT_EXIST));
     }
 
     @Override

--- a/module-domain/src/main/java/org/opensource/user/service/UserService.java
+++ b/module-domain/src/main/java/org/opensource/user/service/UserService.java
@@ -86,4 +86,11 @@ public class UserService implements UserUseCase {
     public User findUserByEmail(String email) {
         return userPersistencePort.findByEmail(email);
     }
+
+    @Override
+    public User findUserById(Long id) {
+        User user = userPersistencePort.findById(id)
+                .orElseThrow(() -> new BadRequestException(UserErrorType.USER_NOT_EXIST));
+        return user;
+    }
 }

--- a/module-infra/persistence-database/src/main/java/org/opensource/user/repository/UserCredentialsJpaRepository.java
+++ b/module-infra/persistence-database/src/main/java/org/opensource/user/repository/UserCredentialsJpaRepository.java
@@ -1,7 +1,12 @@
 package org.opensource.user.repository;
 
+import org.opensource.user.domain.UserCredentials;
 import org.opensource.user.entity.UserCredentialsEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface UserCredentialsJpaRepository extends JpaRepository<UserCredentialsEntity, String> {
+    Optional<UserCredentialsEntity> findByUser_Email(String userEmail);
 }

--- a/module-infra/persistence-database/src/main/java/org/opensource/user/repository/UserCredentialsRepository.java
+++ b/module-infra/persistence-database/src/main/java/org/opensource/user/repository/UserCredentialsRepository.java
@@ -6,6 +6,8 @@ import org.opensource.user.entity.UserCredentialsEntity;
 import org.opensource.user.port.out.persistence.UserCredentialsPersistencePort;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class UserCredentialsRepository implements UserCredentialsPersistencePort {
@@ -14,5 +16,11 @@ public class UserCredentialsRepository implements UserCredentialsPersistencePort
     @Override
     public void save(UserCredentials userCredentials) {
         userCredentialsJpaRepository.save(UserCredentialsEntity.from(userCredentials));
+    }
+
+    @Override
+    public Optional<UserCredentials> findByUserEmail(String email) {
+        return userCredentialsJpaRepository.findByUser_Email(email)
+                .map(UserCredentialsEntity::toModel);
     }
 }

--- a/module-infra/persistence-database/src/main/java/org/opensource/user/repository/UserJpaRepository.java
+++ b/module-infra/persistence-database/src/main/java/org/opensource/user/repository/UserJpaRepository.java
@@ -4,10 +4,12 @@ import org.opensource.user.domain.User;
 import org.opensource.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     boolean existsByEmail(String email);
 
     Boolean existsByName(String name);
 
-    User findByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/module-infra/persistence-database/src/main/java/org/opensource/user/repository/UserRepository.java
+++ b/module-infra/persistence-database/src/main/java/org/opensource/user/repository/UserRepository.java
@@ -6,13 +6,15 @@ import org.opensource.user.entity.UserEntity;
 import org.opensource.user.port.out.persistence.UserPersistencePort;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class UserRepository implements UserPersistencePort {
     private final UserJpaRepository userJpaRepository;
 
     @Override
-    public User findByEmail(String email) {
+    public Optional<User> findByEmail(String email) {
         return userJpaRepository.findByEmail(email);
     }
 
@@ -29,5 +31,10 @@ public class UserRepository implements UserPersistencePort {
     @Override
     public void save(User user) {
         userJpaRepository.save(UserEntity.from(user));
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return userJpaRepository.findById(id).map(UserEntity::toModel);
     }
 }

--- a/module-infra/security/src/main/java/org/opensource/security/adapter/PasswordEncoderAdapter.java
+++ b/module-infra/security/src/main/java/org/opensource/security/adapter/PasswordEncoderAdapter.java
@@ -14,4 +14,9 @@ public class PasswordEncoderAdapter implements PasswordEncoderPort {
     public String encode(String password) {
         return passwordEncoder.encode(password);
     }
+
+    @Override
+    public Boolean matches(String rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
 }

--- a/module-infra/security/src/main/java/org/opensource/security/jwt/JwtUtil.java
+++ b/module-infra/security/src/main/java/org/opensource/security/jwt/JwtUtil.java
@@ -1,0 +1,77 @@
+package org.opensource.security.jwt;
+
+import exception.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.opensource.user.domain.UserCredentials;
+import org.opensource.user.port.out.SecurityPort;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import type.user.UserErrorType;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtUtil implements SecurityPort {
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @PostConstruct
+    protected void init() {
+        jwtSecret = Base64.getEncoder()
+                .encodeToString(jwtSecret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String createToken(UserCredentials userCredentials) {
+        final Date now = new Date();
+
+        return Jwts.builder()
+                .claims()
+                .add("userId", userCredentials.getUser().getId())
+                .and()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + 10000 * 3600 * 1000L))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+
+    @Override
+    public Boolean verifyToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return true;
+        } catch (RuntimeException e) {
+            if (e instanceof ExpiredJwtException) {
+                throw new UnauthorizedException(UserErrorType.TOKEN_TIME_EXPIRED_ERROR);
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public String getJwtContents(String token) {
+        final Claims claims = getBody(token);
+        return (String) claims.get("userId");
+    }
+
+    private Key getSigningKey() {
+        final byte[] keyBytes = jwtSecret.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    private Claims getBody(String token) {
+        return Jwts.parser()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}


### PR DESCRIPTION
## ISSUE 번호
#43 

## 구현 내용

- 로그인 기능을 구현하였습니다.
- 프론트 측의 요구에 따라 refresh token은 따로 구현하지 않았습니다.
- 우선 로그인 부분만 구현하였고 이후 다른 api 호출 시 인증 과정을 구현해야합니다.