### PR TITLE
로그인 인증 기능 구현

### DIFF
--- a/module-application/build.gradle
+++ b/module-application/build.gradle
@@ -24,5 +24,8 @@ project(':module-application') {
 
         /* Swagger */
         implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
+        // spring security
+        implementation "org.springframework.boot:spring-boot-starter-security"
     }
 }

--- a/module-application/src/main/java/org/opensource/user/annotation/LoginUserEmail.java
+++ b/module-application/src/main/java/org/opensource/user/annotation/LoginUserEmail.java
@@ -1,0 +1,14 @@
+package org.opensource.user.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "email == null ? '' : email")
+public @interface LoginUserEmail {
+}

--- a/module-application/src/main/java/org/opensource/user/annotation/LoginUserId.java
+++ b/module-application/src/main/java/org/opensource/user/annotation/LoginUserId.java
@@ -1,0 +1,14 @@
+package org.opensource.user.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "id == null ? 0L : id")
+public @interface LoginUserId {
+}

--- a/module-application/src/main/java/org/opensource/user/annotation/LoginUserName.java
+++ b/module-application/src/main/java/org/opensource/user/annotation/LoginUserName.java
@@ -1,0 +1,14 @@
+package org.opensource.user.annotation;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "name == null ? '' : name")
+public @interface LoginUserName {
+}

--- a/module-application/src/main/resources/yml/application-local.yml
+++ b/module-application/src/main/resources/yml/application-local.yml
@@ -11,7 +11,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/module-common/src/main/java/type/user/UserErrorType.java
+++ b/module-common/src/main/java/type/user/UserErrorType.java
@@ -12,7 +12,11 @@ public enum UserErrorType implements ErrorType {
     EMAIL_NOT_EXIST(400, "등록된 이메일이 없습니다."),
     TOKEN_TIME_EXPIRED_ERROR(401, "토큰 기간이 만료되었습니다."),
     USER_PASSWORD_NOT_MATCH(401, "비밀번호를 잘못 입력하였습니다."),
-    USER_NOT_EXIST(400, "유저가 존재하지 않습니다.")
+    USER_NOT_EXIST(400, "유저가 존재하지 않습니다."),
+    TOKEN_NOT_FOUND(401, "accessToken을 찾을 수 없습니다."),
+    TOKEN_MALFORMED(401, "잘못된 토큰 형식입니다."),
+    TOKEN_INVALID_FORMAT(401, "토큰 포맷이 올바르지 않습니다."),
+    TOKEN_SIGNATURE_INVALID(401, "토큰 서명이 올바르지 않습니다."),
     ;
 
     private final int code;

--- a/module-domain/src/main/java/org/opensource/user/port/out/SecurityPort.java
+++ b/module-domain/src/main/java/org/opensource/user/port/out/SecurityPort.java
@@ -5,7 +5,7 @@ import org.opensource.user.domain.UserCredentials;
 public interface SecurityPort {
     String createToken(UserCredentials userCredentials);
 
-    Boolean verifyToken(String token);
+    void verifyToken(String token);
 
-    String getJwtContents(String token);
+    Long getUserIdFromToken(String token);
 }

--- a/module-infra/security/build.gradle
+++ b/module-infra/security/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     implementation project(':module-domain')
     implementation project(':module-common')
 
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
     // spring security
     implementation "org.springframework.boot:spring-boot-starter-security"
 

--- a/module-infra/security/src/main/java/org/opensource/security/config/SecurityConfig.java
+++ b/module-infra/security/src/main/java/org/opensource/security/config/SecurityConfig.java
@@ -1,31 +1,67 @@
 package org.opensource.security.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.opensource.security.filter.JwtFilter;
+import org.opensource.security.handler.JwtExceptionHandler;
+import org.opensource.security.jwt.JwtUtil;
+import org.opensource.user.port.out.persistence.UserPersistencePort;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final UserPersistencePort userPersistencePort;
+    private final JwtUtil jwtUtil;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(AbstractHttpConfigurer::disable)
-                .headers(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable);
+                .formLogin(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(request ->
+                        request.requestMatchers(
+                                        // email 관련 api 인증 없이 호출 허용
+                                        "/api/v1/email/**",
+                                        // user 관련 api 인증 없이 호출 허용
+                                        "/api/v1/user/**",
+                                        // 예외처리를 직접하지 않은 경우 예외 출력
+                                        "/error").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // jwt filter 추가하여 토큰 검증
+                .addFilterBefore(jwtFilter(userPersistencePort, jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                // jwt token error handler
+                .addFilterBefore(jwtExceptionHandler(), JwtFilter.class);
+
         return http.build();
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public JwtFilter jwtFilter(UserPersistencePort userPersistencePort, JwtUtil jwtUtil) {
+        return new JwtFilter(userPersistencePort, jwtUtil);
+    }
+
+    @Bean
+    public JwtExceptionHandler jwtExceptionHandler() {
+        return new JwtExceptionHandler(new ObjectMapper());
     }
 }

--- a/module-infra/security/src/main/java/org/opensource/security/dto/CustomUser.java
+++ b/module-infra/security/src/main/java/org/opensource/security/dto/CustomUser.java
@@ -1,0 +1,37 @@
+package org.opensource.security.dto;
+
+import lombok.Getter;
+import org.opensource.user.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class CustomUser implements UserDetails {
+    private Long id;
+    private String name;
+    private String email;
+
+    public CustomUser(User user) {
+        this.id = user.getId();
+        this.name = user.getName();
+        this.email = user.getEmail();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.name;
+    }
+}

--- a/module-infra/security/src/main/java/org/opensource/security/filter/JwtFilter.java
+++ b/module-infra/security/src/main/java/org/opensource/security/filter/JwtFilter.java
@@ -1,0 +1,97 @@
+package org.opensource.security.filter;
+
+import exception.BadRequestException;
+import exception.InternalServerException;
+import exception.UnauthorizedException;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jdk.jshell.spi.ExecutionControl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensource.security.dto.CustomUser;
+import org.opensource.security.jwt.JwtUtil;
+import org.opensource.user.domain.User;
+import org.opensource.user.port.out.persistence.UserPersistencePort;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import type.user.UserErrorType;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final UserPersistencePort userPersistencePort;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        log.info("uri: {}", uri);
+        if (noAuthentication(uri)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        log.info("jwt filter called");
+        String jwtToken = parseJwt(request);
+        log.info("jwt token: {}", jwtToken);
+
+        if (jwtToken == null) {
+            throw new UnauthorizedException(UserErrorType.TOKEN_NOT_FOUND);
+        }
+
+        try {
+            jwtUtil.verifyToken(jwtToken);
+        } catch (ExpiredJwtException e) {
+            throw new UnauthorizedException(UserErrorType.TOKEN_TIME_EXPIRED_ERROR);
+        } catch (MalformedJwtException e) {
+            throw new UnauthorizedException(UserErrorType.TOKEN_MALFORMED);
+        } catch (SignatureException e) {
+            throw new UnauthorizedException(UserErrorType.TOKEN_SIGNATURE_INVALID);
+        } catch (Exception e) {
+            throw new InternalServerException(UserErrorType.TOKEN_NOT_FOUND);
+        }
+
+        Long userId = jwtUtil.getUserIdFromToken(jwtToken);
+        log.info("userId: {}", userId);
+        setAuthentication(userId);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String parseJwt(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        return null;
+    }
+
+    private void setAuthentication(Long userId) {
+        User user = userPersistencePort.findById(userId)
+                .orElseThrow(() -> new BadRequestException(UserErrorType.USER_NOT_EXIST));
+
+        CustomUser customUser = new CustomUser(user);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                customUser, null, customUser.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private boolean noAuthentication(String uri) {
+        return uri.startsWith("/api/v1/email/")
+                || uri.startsWith("/api/v1/user/");
+    }
+}

--- a/module-infra/security/src/main/java/org/opensource/security/handler/JwtExceptionHandler.java
+++ b/module-infra/security/src/main/java/org/opensource/security/handler/JwtExceptionHandler.java
@@ -1,0 +1,38 @@
+package org.opensource.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import exception.BaseException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensource.security.jwt.dto.ErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtExceptionHandler extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (BaseException e) {
+            response.setCharacterEncoding("UTF-8");
+            response.setStatus(e.getHttpStatus().value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            ErrorResponse res =
+                    new ErrorResponse(
+                            e.getHttpStatus().value(),
+                            e.getErrorType().getMessage());
+            response.getWriter().write(objectMapper.writeValueAsString(res));
+        }
+    }
+}

--- a/module-infra/security/src/main/java/org/opensource/security/jwt/JwtUtil.java
+++ b/module-infra/security/src/main/java/org/opensource/security/jwt/JwtUtil.java
@@ -1,8 +1,6 @@
 package org.opensource.security.jwt;
 
-import exception.UnauthorizedException;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -10,7 +8,6 @@ import org.opensource.user.domain.UserCredentials;
 import org.opensource.user.port.out.SecurityPort;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import type.user.UserErrorType;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -44,22 +41,24 @@ public class JwtUtil implements SecurityPort {
 
 
     @Override
-    public Boolean verifyToken(String token) {
-        try {
-            final Claims claims = getBody(token);
-            return true;
-        } catch (RuntimeException e) {
-            if (e instanceof ExpiredJwtException) {
-                throw new UnauthorizedException(UserErrorType.TOKEN_TIME_EXPIRED_ERROR);
-            }
-            return false;
-        }
+    public void verifyToken(String token) {
+        final Claims claims = getBody(token);
     }
 
     @Override
-    public String getJwtContents(String token) {
+    public Long getUserIdFromToken(String token) {
         final Claims claims = getBody(token);
-        return (String) claims.get("userId");
+        Object userId = claims.get("userId");
+
+        if (userId instanceof Integer) {
+            return ((Integer) userId).longValue();
+        } else if (userId instanceof Long) {
+            return (Long) userId;
+        } else if (userId instanceof String) {
+            return Long.parseLong((String) userId);
+        } else {
+            throw new IllegalArgumentException("Invalid type for userId in JWT");
+        }
     }
 
     private Key getSigningKey() {

--- a/module-infra/security/src/main/java/org/opensource/security/jwt/dto/ErrorResponse.java
+++ b/module-infra/security/src/main/java/org/opensource/security/jwt/dto/ErrorResponse.java
@@ -1,0 +1,4 @@
+package org.opensource.security.jwt.dto;
+
+public record ErrorResponse(Integer status, String message) {
+}


### PR DESCRIPTION
# ISSUE 번호
#43 

# 구현 내용

### 인증 구현
* JwtFilter를 사용하여 api 호출 시 인증 됐는지 검사하도록 구현하였습니다.
* security FilterChain에 JwtFilter, JwtExceptionHandler를 추가해주었습니다.
* 이메일 인증, 회원가입, 로그인 기능의 경우 인증을 하지 않아도 되도록 permitAll()을 해주었습니다.
* /error 경로도 permit을 해주어 따로 예외처리를 하지 않은 경우에도 어떤 에러인지 확인할 수 있도록 해주었습니다.
* 이외의 경로는 전부 검사하도록 하였습니다.

### annotation 구현
* LoginUserId, LoginUserName, LoginUserEmail 어노테이션을 추가하였습니다.
* JwtFilter를 통해 인증된 경우 로그인한 유저 정보가 저장됩니다.
* 인증 성공한 경우 위 구현된 어노테이션을 통해 id, name, email을 불러올 수 있습니다.